### PR TITLE
Switch storage to ClickHouse and add Postgres export/load tools

### DIFF
--- a/cmd/adduser/main.go
+++ b/cmd/adduser/main.go
@@ -41,10 +41,35 @@ func main() {
 		os.Exit(1)
 	}
 
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
+
+	userID := database.HashID(username)
+	var existingID int64
+
+	row := conn.QueryRow(
+		`select user_id
+		from crypto_user_login
+		where username = ? and is_active = 1
+		order by updated_at desc
+		limit 1`,
+		username,
+	)
+
+	if err := row.Scan(&existingID); err == nil {
+		fmt.Fprintf(os.Stderr, "User already exists.\n")
+		os.Exit(1)
+	} else if err != database.ErrNoRows {
+		fmt.Fprintf(os.Stderr, "Query error: %s\n", err)
+		os.Exit(1)
+	}
 
 	err = conn.Exec(
-		"insert into crypto_user(username, password) values($1, $2)",
+		`insert into crypto_user_login
+			(user_id, username, password_hash, created_at, updated_at, is_active)
+		values (?, ?, ?, now64(9), now64(9), 1)`,
+		userID,
 		username,
 		string(passwordHash),
 	)

--- a/cmd/export-postgres/main.go
+++ b/cmd/export-postgres/main.go
@@ -1,0 +1,652 @@
+// Export Postgres tables into CSV files for ClickHouse imports.
+package main
+
+import (
+	"context"
+	"encoding/csv"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/dense-analysis/pricewarp/internal/env"
+	"github.com/jackc/pgx/v4"
+)
+
+type exportConfig struct {
+	outputDir  string
+	createdAt  time.Time
+	updatedAt  time.Time
+	pgHost     string
+	pgPort     string
+	pgUser     string
+	pgPassword string
+	pgDatabase string
+}
+
+func main() {
+	env.LoadEnvironmentVariables()
+
+	config := buildConfig()
+
+	conn, err := pgx.Connect(
+		context.Background(),
+		fmt.Sprintf(
+			"postgres://%s:%s@%s:%s/%s",
+			config.pgUser,
+			config.pgPassword,
+			config.pgHost,
+			config.pgPort,
+			config.pgDatabase,
+		),
+	)
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Connection error: %s\n", err)
+		os.Exit(1)
+	}
+
+	defer conn.Close(context.Background())
+
+	if err := os.MkdirAll(config.outputDir, 0o755); err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating output directory: %s\n", err)
+		os.Exit(1)
+	}
+
+	if err := exportUsers(conn, config); err != nil {
+		exitWithError("Export users", err)
+	}
+
+	if err := exportCurrencies(conn, config); err != nil {
+		exitWithError("Export currencies", err)
+	}
+
+	if err := exportPrices(conn, config); err != nil {
+		exitWithError("Export prices", err)
+	}
+
+	if err := exportAlerts(conn, config); err != nil {
+		exitWithError("Export alerts", err)
+	}
+
+	if err := exportPortfolios(conn, config); err != nil {
+		exitWithError("Export portfolios", err)
+	}
+
+	if err := exportAssets(conn, config); err != nil {
+		exitWithError("Export assets", err)
+	}
+}
+
+func buildConfig() exportConfig {
+	now := time.Now().UTC()
+
+	return exportConfig{
+		outputDir:  argOrDefault(1, "export"),
+		createdAt:  now,
+		updatedAt:  now,
+		pgHost:     envOrDefault("PG_HOST", os.Getenv("DB_HOST")),
+		pgPort:     envOrDefault("PG_PORT", os.Getenv("DB_PORT")),
+		pgUser:     envOrDefault("PG_USERNAME", os.Getenv("DB_USERNAME")),
+		pgPassword: envOrDefault("PG_PASSWORD", os.Getenv("DB_PASSWORD")),
+		pgDatabase: envOrDefault("PG_DATABASE", os.Getenv("DB_NAME")),
+	}
+}
+
+func exportUsers(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(context.Background(), "select id, username, password from crypto_user order by id")
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_user_login.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{
+		"user_id",
+		"username",
+		"password_hash",
+		"created_at",
+		"updated_at",
+		"is_active",
+	}); err != nil {
+		return err
+	}
+
+	createdAt := formatTime(config.createdAt)
+	updatedAt := formatTime(config.updatedAt)
+
+	for rows.Next() {
+		var id int64
+		var username string
+		var password string
+
+		if err := rows.Scan(&id, &username, &password); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			fmt.Sprintf("%d", id),
+			username,
+			password,
+			createdAt,
+			updatedAt,
+			"1",
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func exportCurrencies(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(context.Background(), "select id, ticker, name from crypto_currency order by id")
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_currency.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{"id", "ticker", "name", "updated_at"}); err != nil {
+		return err
+	}
+
+	updatedAt := formatTime(config.updatedAt)
+
+	for rows.Next() {
+		var id int64
+		var ticker string
+		var name string
+
+		if err := rows.Scan(&id, &ticker, &name); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			fmt.Sprintf("%d", id),
+			ticker,
+			name,
+			updatedAt,
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func exportPrices(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(
+		context.Background(),
+		`
+			select
+				price.time,
+				from_currency.id,
+				from_currency.ticker,
+				from_currency.name,
+				to_currency.id,
+				to_currency.ticker,
+				to_currency.name,
+				price.value
+			from crypto_price as price
+			inner join crypto_currency as from_currency
+				on from_currency.id = price."from"
+			inner join crypto_currency as to_currency
+				on to_currency.id = price."to"
+			order by price.time
+		`,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_currency_prices.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{
+		"time",
+		"from_currency_id",
+		"from_currency_ticker",
+		"from_currency_name",
+		"to_currency_id",
+		"to_currency_ticker",
+		"to_currency_name",
+		"value",
+	}); err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var timestamp time.Time
+		var fromID int64
+		var fromTicker string
+		var fromName string
+		var toID int64
+		var toTicker string
+		var toName string
+		var value string
+
+		if err := rows.Scan(
+			&timestamp,
+			&fromID,
+			&fromTicker,
+			&fromName,
+			&toID,
+			&toTicker,
+			&toName,
+			&value,
+		); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			formatTime(timestamp),
+			fmt.Sprintf("%d", fromID),
+			fromTicker,
+			fromName,
+			fmt.Sprintf("%d", toID),
+			toTicker,
+			toName,
+			value,
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func exportAlerts(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(
+		context.Background(),
+		`
+			select
+				alert.id,
+				alert.user_id,
+				crypto_user.username,
+				from_currency.id,
+				from_currency.ticker,
+				from_currency.name,
+				to_currency.id,
+				to_currency.ticker,
+				to_currency.name,
+				alert.value,
+				alert.above,
+				alert.time,
+				alert.sent
+			from crypto_alert as alert
+			inner join crypto_user
+				on crypto_user.id = alert.user_id
+			inner join crypto_currency as from_currency
+				on from_currency.id = alert."from"
+			inner join crypto_currency as to_currency
+				on to_currency.id = alert."to"
+			order by alert.time
+		`,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_alert.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{
+		"alert_id",
+		"user_id",
+		"username",
+		"from_currency_id",
+		"from_currency_ticker",
+		"from_currency_name",
+		"to_currency_id",
+		"to_currency_ticker",
+		"to_currency_name",
+		"value",
+		"above",
+		"alert_time",
+		"sent",
+		"updated_at",
+		"is_deleted",
+	}); err != nil {
+		return err
+	}
+
+	for rows.Next() {
+		var alertID int64
+		var userID int64
+		var username string
+		var fromID int64
+		var fromTicker string
+		var fromName string
+		var toID int64
+		var toTicker string
+		var toName string
+		var value string
+		var above bool
+		var alertTime time.Time
+		var sent bool
+
+		if err := rows.Scan(
+			&alertID,
+			&userID,
+			&username,
+			&fromID,
+			&fromTicker,
+			&fromName,
+			&toID,
+			&toTicker,
+			&toName,
+			&value,
+			&above,
+			&alertTime,
+			&sent,
+		); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			fmt.Sprintf("%d", alertID),
+			fmt.Sprintf("%d", userID),
+			username,
+			fmt.Sprintf("%d", fromID),
+			fromTicker,
+			fromName,
+			fmt.Sprintf("%d", toID),
+			toTicker,
+			toName,
+			value,
+			boolToUInt8(above),
+			formatTime(alertTime),
+			boolToUInt8(sent),
+			formatTime(alertTime),
+			"0",
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func exportPortfolios(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(
+		context.Background(),
+		`
+			select
+				portfolio.user_id,
+				crypto_user.username,
+				portfolio.currency_id,
+				currency.ticker,
+				currency.name,
+				portfolio.cash
+			from crypto_portfolio as portfolio
+			inner join crypto_user
+				on crypto_user.id = portfolio.user_id
+			inner join crypto_currency as currency
+				on currency.id = portfolio.currency_id
+			order by portfolio.user_id
+		`,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_portfolio.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{
+		"user_id",
+		"username",
+		"currency_id",
+		"currency_ticker",
+		"currency_name",
+		"cash",
+		"updated_at",
+		"is_deleted",
+	}); err != nil {
+		return err
+	}
+
+	updatedAt := formatTime(config.updatedAt)
+
+	for rows.Next() {
+		var userID int64
+		var username string
+		var currencyID int64
+		var ticker string
+		var name string
+		var cash string
+
+		if err := rows.Scan(&userID, &username, &currencyID, &ticker, &name, &cash); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			fmt.Sprintf("%d", userID),
+			username,
+			fmt.Sprintf("%d", currencyID),
+			ticker,
+			name,
+			cash,
+			updatedAt,
+			"0",
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func exportAssets(conn *pgx.Conn, config exportConfig) error {
+	rows, err := conn.Query(
+		context.Background(),
+		`
+			select
+				asset.user_id,
+				crypto_user.username,
+				asset.currency_id,
+				currency.ticker,
+				currency.name,
+				asset.purchased,
+				asset.amount
+			from crypto_asset as asset
+			inner join crypto_user
+				on crypto_user.id = asset.user_id
+			inner join crypto_currency as currency
+				on currency.id = asset.currency_id
+			order by asset.user_id, asset.currency_id
+		`,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	defer rows.Close()
+
+	path := filepath.Join(config.outputDir, "crypto_asset.csv")
+	writer, file, err := createCSV(path)
+
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	if err := writer.Write([]string{
+		"user_id",
+		"username",
+		"currency_id",
+		"currency_ticker",
+		"currency_name",
+		"purchased",
+		"amount",
+		"updated_at",
+		"is_deleted",
+	}); err != nil {
+		return err
+	}
+
+	updatedAt := formatTime(config.updatedAt)
+
+	for rows.Next() {
+		var userID int64
+		var username string
+		var currencyID int64
+		var ticker string
+		var name string
+		var purchased string
+		var amount string
+
+		if err := rows.Scan(
+			&userID,
+			&username,
+			&currencyID,
+			&ticker,
+			&name,
+			&purchased,
+			&amount,
+		); err != nil {
+			return err
+		}
+
+		if err := writer.Write([]string{
+			fmt.Sprintf("%d", userID),
+			username,
+			fmt.Sprintf("%d", currencyID),
+			ticker,
+			name,
+			purchased,
+			amount,
+			updatedAt,
+			"0",
+		}); err != nil {
+			return err
+		}
+	}
+
+	writer.Flush()
+	if err := writer.Error(); err != nil {
+		return err
+	}
+
+	return rows.Err()
+}
+
+func createCSV(path string) (*csv.Writer, *os.File, error) {
+	file, err := os.Create(path)
+
+	if err != nil {
+		return nil, nil, err
+	}
+
+	writer := csv.NewWriter(file)
+
+	return writer, file, nil
+}
+
+func formatTime(t time.Time) string {
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+func boolToUInt8(value bool) string {
+	if value {
+		return "1"
+	}
+
+	return "0"
+}
+
+func argOrDefault(position int, fallback string) string {
+	if len(os.Args) > position {
+		return os.Args[position]
+	}
+
+	return fallback
+}
+
+func envOrDefault(name, fallback string) string {
+	if value := os.Getenv(name); value != "" {
+		return value
+	}
+
+	return fallback
+}
+
+func exitWithError(action string, err error) {
+	fmt.Fprintf(os.Stderr, "%s error: %s\n", action, err)
+	os.Exit(1)
+}

--- a/cmd/ingest/main.go
+++ b/cmd/ingest/main.go
@@ -90,57 +90,100 @@ func readPrices(results []BinanceTickerResult) []CryptoPrice {
 	return prices
 }
 
-func writeCurrencies(transaction *database.Tx, prices []CryptoPrice) error {
-	tickerRows, err := transaction.Query("SELECT ticker from crypto_currency")
+func writeCurrencies(conn *database.Conn, prices []CryptoPrice) error {
+	tickerRows, err := conn.Query("SELECT ticker from crypto_currency")
 
 	if err != nil {
 		return err
 	}
+	defer tickerRows.Close()
 
 	currentTickerMap := map[string]bool{}
 
 	for tickerRows.Next() {
 		var ticker string
-		tickerRows.Scan(&ticker)
+		if err := tickerRows.Scan(&ticker); err != nil {
+			return err
+		}
 		currentTickerMap[ticker] = true
 	}
 
-	var inputRows [][]interface{}
-
-	for _, price := range prices {
-		for _, ticker := range []string{price.From, price.To} {
-			if !currentTickerMap[ticker] {
-				inputRows = append(inputRows, []interface{}{ticker, ticker})
-				currentTickerMap[ticker] = true
-			}
-		}
+	if err := tickerRows.Err(); err != nil {
+		return err
 	}
 
-	if len(inputRows) > 0 {
-		_, err = transaction.CopyFrom("crypto_currency", []string{"ticker", "name"}, inputRows)
-	}
-
-	return err
-}
-
-func writePrices(transaction *database.Tx, prices []CryptoPrice) error {
-	timestamp := time.Now()
-	tickerRows, err := transaction.Query("SELECT id, ticker from crypto_currency")
+	batch, err := conn.PrepareBatch(
+		`insert into crypto_currency (id, ticker, name, updated_at)
+		values (?, ?, ?, now64(9))`,
+	)
 
 	if err != nil {
 		return err
 	}
 
-	tickerMap := map[string]int{}
+	rowCount := 0
 
-	for tickerRows.Next() {
-		var id int
-		var ticker string
-		tickerRows.Scan(&id, &ticker)
-		tickerMap[ticker] = id
+	for _, price := range prices {
+		for _, ticker := range []string{price.From, price.To} {
+			if !currentTickerMap[ticker] {
+				if err := batch.Append(database.HashID(ticker), ticker, ticker); err != nil {
+					return err
+				}
+
+				rowCount += 1
+				currentTickerMap[ticker] = true
+			}
+		}
 	}
 
-	var inputRows [][]interface{}
+	if rowCount == 0 {
+		return nil
+	}
+
+	return batch.Send()
+}
+
+func writePrices(conn *database.Conn, prices []CryptoPrice) error {
+	timestamp := time.Now()
+	tickerRows, err := conn.Query("SELECT id, ticker, name from crypto_currency")
+
+	if err != nil {
+		return err
+	}
+	defer tickerRows.Close()
+
+	type currencyInfo struct {
+		ID   int64
+		Name string
+	}
+	tickerMap := map[string]currencyInfo{}
+
+	for tickerRows.Next() {
+		var id int64
+		var ticker string
+		var name string
+		if err := tickerRows.Scan(&id, &ticker, &name); err != nil {
+			return err
+		}
+		tickerMap[ticker] = currencyInfo{ID: id, Name: name}
+	}
+
+	if err := tickerRows.Err(); err != nil {
+		return err
+	}
+
+	batch, err := conn.PrepareBatch(
+		`insert into crypto_currency_prices
+			(time, from_currency_id, from_currency_ticker, from_currency_name,
+			 to_currency_id, to_currency_ticker, to_currency_name, value)
+		values (?, ?, ?, ?, ?, ?, ?, ?)`,
+	)
+
+	if err != nil {
+		return err
+	}
+
+	rowCount := 0
 
 	for _, price := range prices {
 		decimalValue, decimalErr := decimal.NewFromString(price.Value)
@@ -154,19 +197,36 @@ func writePrices(transaction *database.Tx, prices []CryptoPrice) error {
 			decimalValue = VerySmallAmount
 		}
 
-		inputRows = append(inputRows, []interface{}{
-			tickerMap[price.From],
-			tickerMap[price.To],
+		fromInfo, ok := tickerMap[price.From]
+		if !ok {
+			return fmt.Errorf("missing currency info for %s", price.From)
+		}
+		toInfo, ok := tickerMap[price.To]
+		if !ok {
+			return fmt.Errorf("missing currency info for %s", price.To)
+		}
+
+		if err := batch.Append(
 			timestamp,
-			decimalValue,
-		})
+			fromInfo.ID,
+			price.From,
+			fromInfo.Name,
+			toInfo.ID,
+			price.To,
+			toInfo.Name,
+			decimalToFloat(decimalValue),
+		); err != nil {
+			return err
+		}
+
+		rowCount += 1
 	}
 
-	if len(inputRows) > 0 {
-		_, err = transaction.CopyFrom("crypto_price", []string{"from", "to", "time", "value"}, inputRows)
+	if rowCount == 0 {
+		return nil
 	}
 
-	return err
+	return batch.Send()
 }
 
 func main() {
@@ -179,7 +239,9 @@ func main() {
 		os.Exit(1)
 	}
 
-	defer conn.Close()
+	defer func() {
+		_ = conn.Close()
+	}()
 
 	tickerResults, err := readBinanceTickerResults()
 
@@ -190,28 +252,23 @@ func main() {
 
 	prices := readPrices(tickerResults)
 
-	transaction, err := conn.Begin()
+	err = writeCurrencies(conn, prices)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SQL error: %s\n", err)
 		os.Exit(1)
 	}
 
-	defer transaction.Rollback()
-
-	err = writeCurrencies(transaction, prices)
+	err = writePrices(conn, prices)
 
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "SQL error: %s\n", err)
 		os.Exit(1)
 	}
+}
 
-	err = writePrices(transaction, prices)
+func decimalToFloat(value decimal.Decimal) float64 {
+	floatValue, _ := value.Float64()
 
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "SQL error: %s\n", err)
-		os.Exit(1)
-	}
-
-	transaction.Commit()
+	return floatValue
 }

--- a/cmd/pricewarp/main.go
+++ b/cmd/pricewarp/main.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/dense-analysis/pricewarp/internal/database"
 	"github.com/dense-analysis/pricewarp/internal/env"
 	"github.com/dense-analysis/pricewarp/internal/model"
@@ -20,6 +19,7 @@ import (
 	"github.com/dense-analysis/pricewarp/internal/route/util"
 	"github.com/dense-analysis/pricewarp/internal/session"
 	"github.com/dense-analysis/pricewarp/internal/template"
+	"github.com/gorilla/mux"
 )
 
 func handleIndex(conn *database.Conn, writer http.ResponseWriter, request *http.Request) {
@@ -44,7 +44,9 @@ func addDatabaseConnection(
 		if err != nil {
 			util.RespondInternalServerError(writer, err)
 		} else {
-			defer conn.Close()
+			defer func() {
+				_ = conn.Close()
+			}()
 			f(conn, writer, request)
 		}
 	}

--- a/condense-prices.sh
+++ b/condense-prices.sh
@@ -5,5 +5,5 @@ set -eu
 #shellcheck disable=SC2046
 export $(xargs < .env)
 
-PGPASSWORD="$DB_PASSWORD" psql -q -h "$DB_HOST" "$DB_NAME" "$DB_USERNAME" \
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
     < sql/condense-prices.sql

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/dense-analysis/pricewarp
 go 1.18
 
 require (
+	github.com/ClickHouse/clickhouse-go/v2 v2.13.0
 	github.com/gorilla/mux v1.8.0
 	github.com/gorilla/sessions v1.2.1
 	github.com/jackc/pgtype v1.9.1
@@ -13,6 +14,8 @@ require (
 )
 
 require (
+	github.com/ClickHouse/ch-go v0.58.1 // indirect
+	github.com/andybalholm/brotli v1.0.5 // indirect
 	github.com/gorilla/securecookie v1.1.1 // indirect
 	github.com/jackc/chunkreader/v2 v2.0.1 // indirect
 	github.com/jackc/pgconn v1.10.1 // indirect
@@ -21,5 +24,6 @@ require (
 	github.com/jackc/pgproto3/v2 v2.2.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20200714003250-2b9c44734f2b // indirect
 	github.com/jackc/puddle v1.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	golang.org/x/text v0.3.7 // indirect
 )

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -8,13 +8,13 @@ import (
 
 // User represents a user in the database
 type User struct {
-	ID       int
+	ID       int64
 	Username string
 }
 
 // Currency represents a currency in the database
 type Currency struct {
-	ID     int
+	ID     int64
 	Ticker string
 	Name   string
 }
@@ -29,7 +29,7 @@ type Price struct {
 
 // Alert represents an alert configured by a user
 type Alert struct {
-	ID    int
+	ID    int64
 	From  Currency
 	To    Currency
 	Value decimal.Decimal

--- a/internal/model/model_query.go
+++ b/internal/model/model_query.go
@@ -20,6 +20,7 @@ func LoadList[T any](
 	if err != nil {
 		return err
 	}
+	defer rows.Close()
 
 	*list = make([]T, 0, capacity)
 	var instance T
@@ -32,5 +33,5 @@ func LoadList[T any](
 		*list = append(*list, instance)
 	}
 
-	return nil
+	return rows.Err()
 }

--- a/internal/route/alert/alert.go
+++ b/internal/route/alert/alert.go
@@ -5,50 +5,83 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/gorilla/mux"
-	"github.com/shopspring/decimal"
 	"github.com/dense-analysis/pricewarp/internal/database"
 	"github.com/dense-analysis/pricewarp/internal/model"
 	"github.com/dense-analysis/pricewarp/internal/route/query"
 	"github.com/dense-analysis/pricewarp/internal/route/util"
 	"github.com/dense-analysis/pricewarp/internal/session"
 	"github.com/dense-analysis/pricewarp/internal/template"
+	"github.com/gorilla/mux"
+	"github.com/shopspring/decimal"
 )
 
 var alertQuery = `
 select
-	crypto_alert.id,
+	alert_id,
 	above,
-	time,
+	alert_time,
 	sent,
 	value,
-	from_currency.id,
-	from_currency.ticker,
-	from_currency.name,
-	to_currency.id,
-	to_currency.ticker,
-	to_currency.name
-from crypto_alert
-inner join crypto_currency as from_currency
-on from_currency.id = crypto_alert."from"
-inner join crypto_currency as to_currency
-on to_currency.id = crypto_alert."to"
+	from_currency_id,
+	from_currency_ticker,
+	from_currency_name,
+	to_currency_id,
+	to_currency_ticker,
+	to_currency_name,
+	is_deleted
+from (
+	select
+		alert_id,
+		above,
+		alert_time,
+		sent,
+		value,
+		from_currency_id,
+		from_currency_ticker,
+		from_currency_name,
+		to_currency_id,
+		to_currency_ticker,
+		to_currency_name,
+		is_deleted
+	from crypto_alert
+	where user_id = ?
+	order by updated_at desc
+	limit 1 by alert_id
+)
 `
 
 func scanAlert(row database.Row, alert *model.Alert) error {
-	return row.Scan(
+	var value float64
+	var above uint8
+	var sent uint8
+	var isDeleted uint8
+
+	if err := row.Scan(
 		&alert.ID,
-		&alert.Above,
+		&above,
 		&alert.Time,
-		&alert.Sent,
-		&alert.Value,
+		&sent,
+		&value,
 		&alert.From.ID,
 		&alert.From.Ticker,
 		&alert.From.Name,
 		&alert.To.ID,
 		&alert.To.Ticker,
 		&alert.To.Name,
-	)
+		&isDeleted,
+	); err != nil {
+		return err
+	}
+
+	if isDeleted == 1 {
+		return database.ErrNoRows
+	}
+
+	alert.Above = above == 1
+	alert.Sent = sent == 1
+	alert.Value = decimal.NewFromFloat(value)
+
+	return nil
 }
 
 var currencyQuery = `select id, ticker, name from crypto_currency `
@@ -57,13 +90,13 @@ func scanCurrency(row database.Row, currency *model.Currency) error {
 	return row.Scan(&currency.ID, &currency.Ticker, &currency.Name)
 }
 
-func loadAlertList(conn *database.Conn, userID int, alertList *[]model.Alert) error {
+func loadAlertList(conn *database.Conn, userID int64, alertList *[]model.Alert) error {
 	return model.LoadList(
 		conn,
 		alertList,
 		1,
 		scanAlert,
-		alertQuery+"where user_id = $1 order by time",
+		alertQuery+"where is_deleted = 0 order by alert_time",
 		userID,
 	)
 }
@@ -135,7 +168,7 @@ func loadAlertForRequest(
 	user *model.User,
 	alert *model.Alert,
 ) bool {
-	alertID, err := strconv.Atoi(mux.Vars(request)["id"])
+	alertID, err := strconv.ParseInt(mux.Vars(request)["id"], 10, 64)
 
 	if err != nil {
 		util.RespondNotFound(writer)
@@ -143,7 +176,27 @@ func loadAlertForRequest(
 		return false
 	}
 
-	row := conn.QueryRow(alertQuery+" where user_id = $1 and crypto_alert.id = $2", user.ID, alertID)
+	row := conn.QueryRow(
+		`select
+			alert_id,
+			above,
+			alert_time,
+			sent,
+			value,
+			from_currency_id,
+			from_currency_ticker,
+			from_currency_name,
+			to_currency_id,
+			to_currency_ticker,
+			to_currency_name,
+			is_deleted
+		from crypto_alert
+		where user_id = ? and alert_id = ?
+		order by updated_at desc
+		limit 1`,
+		user.ID,
+		alertID,
+	)
 
 	if err := scanAlert(row, alert); err != nil {
 		if err == database.ErrNoRows {
@@ -187,7 +240,7 @@ func loadAlertFromForm(
 	var err error
 	request.ParseForm()
 
-	from, err := strconv.Atoi(request.Form.Get("from"))
+	from, err := strconv.ParseInt(request.Form.Get("from"), 10, 64)
 
 	if err != nil {
 		util.RespondValidationError(writer, "Invalid from currency ID")
@@ -195,7 +248,7 @@ func loadAlertFromForm(
 		return false
 	}
 
-	to, err := strconv.Atoi(request.Form.Get("to"))
+	to, err := strconv.ParseInt(request.Form.Get("to"), 10, 64)
 
 	if err != nil {
 		util.RespondValidationError(writer, "Invalid to currency ID")
@@ -235,7 +288,7 @@ func loadAlertFromForm(
 
 	var row database.Row
 
-	row = conn.QueryRow(currencyQuery+"where id = $1", from)
+	row = conn.QueryRow(currencyQuery+"where id = ?", from)
 
 	if err := scanCurrency(row, &alert.From); err != nil {
 		util.RespondInternalServerError(writer, err)
@@ -243,7 +296,7 @@ func loadAlertFromForm(
 		return false
 	}
 
-	row = conn.QueryRow(currencyQuery+"where id = $1", to)
+	row = conn.QueryRow(currencyQuery+"where id = ?", to)
 
 	if err := scanCurrency(row, &alert.To); err != nil {
 		util.RespondInternalServerError(writer, err)
@@ -265,12 +318,40 @@ func HandleSubmitAlert(conn *database.Conn, writer http.ResponseWriter, request 
 	}
 
 	if loadAlertFromForm(conn, writer, request, &alert) {
+		alertID, err := database.RandomID()
+
+		if err != nil {
+			util.RespondInternalServerError(writer, err)
+
+			return
+		}
+
 		insertSQL := `
-		insert into crypto_alert(user_id, above, time, sent, value, "from", "to")
-		values ($1, $2, NOW(), false, $3, $4, $5)
+		insert into crypto_alert
+			(alert_id, user_id, username, above, alert_time, sent, value,
+			 from_currency_id, from_currency_ticker, from_currency_name,
+			 to_currency_id, to_currency_ticker, to_currency_name,
+			 updated_at, is_deleted)
+		values (?, ?, ?, ?, now64(9), 0, ?,
+			?, ?, ?,
+			?, ?, ?,
+			now64(9), 0)
 		`
 
-		if err := conn.Exec(insertSQL, user.ID, alert.Above, alert.Value, alert.From.ID, alert.To.ID); err != nil {
+		if err := conn.Exec(
+			insertSQL,
+			alertID,
+			user.ID,
+			user.Username,
+			boolToUint(alert.Above),
+			decimalToFloat(alert.Value),
+			alert.From.ID,
+			alert.From.Ticker,
+			alert.From.Name,
+			alert.To.ID,
+			alert.To.Ticker,
+			alert.To.Name,
+		); err != nil {
 			util.RespondInternalServerError(writer, err)
 		} else {
 			http.Redirect(writer, request, "/alert", http.StatusFound)
@@ -290,17 +371,31 @@ func HandleUpdateAlert(conn *database.Conn, writer http.ResponseWriter, request 
 
 	if loadAlertForRequest(conn, writer, request, &user, &alert) && loadAlertFromForm(conn, writer, request, &alert) {
 		updateSQL := `
-		update crypto_alert
-		set above = $2,
-			time = NOW(),
-			sent = false,
-			value = $3,
-			"from" = $4,
-			"to" = $5
-		where id = $1
+		insert into crypto_alert
+			(alert_id, user_id, username, above, alert_time, sent, value,
+			 from_currency_id, from_currency_ticker, from_currency_name,
+			 to_currency_id, to_currency_ticker, to_currency_name,
+			 updated_at, is_deleted)
+		values (?, ?, ?, ?, now64(9), 0, ?,
+			?, ?, ?,
+			?, ?, ?,
+			now64(9), 0)
 		`
 
-		if err := conn.Exec(updateSQL, alert.ID, alert.Above, alert.Value, alert.From.ID, alert.To.ID); err != nil {
+		if err := conn.Exec(
+			updateSQL,
+			alert.ID,
+			user.ID,
+			user.Username,
+			boolToUint(alert.Above),
+			decimalToFloat(alert.Value),
+			alert.From.ID,
+			alert.From.Ticker,
+			alert.From.Name,
+			alert.To.ID,
+			alert.To.Ticker,
+			alert.To.Name,
+		); err != nil {
 			util.RespondInternalServerError(writer, err)
 		} else {
 			http.Redirect(writer, request, "/alert", http.StatusFound)
@@ -319,10 +414,51 @@ func HandleDeleteAlert(conn *database.Conn, writer http.ResponseWriter, request 
 	}
 
 	if loadAlertForRequest(conn, writer, request, &user, &alert) {
-		if err := conn.Exec("delete from crypto_alert where id = $1", alert.ID); err != nil {
+		deleteSQL := `
+		insert into crypto_alert
+			(alert_id, user_id, username, above, alert_time, sent, value,
+			 from_currency_id, from_currency_ticker, from_currency_name,
+			 to_currency_id, to_currency_ticker, to_currency_name,
+			 updated_at, is_deleted)
+		values (?, ?, ?, ?, ?, ?, ?,
+			?, ?, ?,
+			?, ?, ?,
+			now64(9), 1)
+		`
+
+		if err := conn.Exec(
+			deleteSQL,
+			alert.ID,
+			user.ID,
+			user.Username,
+			boolToUint(alert.Above),
+			alert.Time,
+			boolToUint(alert.Sent),
+			decimalToFloat(alert.Value),
+			alert.From.ID,
+			alert.From.Ticker,
+			alert.From.Name,
+			alert.To.ID,
+			alert.To.Ticker,
+			alert.To.Name,
+		); err != nil {
 			util.RespondInternalServerError(writer, err)
 		} else {
 			writer.WriteHeader(http.StatusNoContent)
 		}
 	}
+}
+
+func decimalToFloat(value decimal.Decimal) float64 {
+	floatValue, _ := value.Float64()
+
+	return floatValue
+}
+
+func boolToUint(value bool) uint8 {
+	if value {
+		return 1
+	}
+
+	return 0
 }

--- a/internal/route/auth/auth.go
+++ b/internal/route/auth/auth.go
@@ -30,12 +30,16 @@ func HandleLogin(conn *database.Conn, writer http.ResponseWriter, request *http.
 	username := request.Form.Get("username")
 	password := request.Form.Get("password")
 
-	var userID int
+	var userID int64
 	loginValid := false
 
 	if len(username) > 0 && len(password) > 0 {
 		row := conn.QueryRow(
-			"select id, password from crypto_user where username = $1",
+			`select user_id, password_hash
+			from crypto_user_login
+			where username = ? and is_active = 1
+			order by updated_at desc
+			limit 1`,
 			username,
 		)
 

--- a/internal/route/query/query.go
+++ b/internal/route/query/query.go
@@ -25,8 +25,8 @@ func LoadCurrencyList(conn *database.Conn, currencyList *[]model.Currency) error
 }
 
 // LoadCurrencyByID loads a single by ID.
-func LoadCurrencyByID(conn *database.Conn, currency *model.Currency, currencyID int) error {
-	row := conn.QueryRow(currencyQuery+"where id = $1", currencyID)
+func LoadCurrencyByID(conn *database.Conn, currency *model.Currency, currencyID int64) error {
+	row := conn.QueryRow(currencyQuery+"where id = ?", currencyID)
 
 	return scanCurrency(row, currency)
 }

--- a/internal/session/session.go
+++ b/internal/session/session.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/gorilla/sessions"
 	"github.com/dense-analysis/pricewarp/internal/database"
 	"github.com/dense-analysis/pricewarp/internal/model"
+	"github.com/gorilla/sessions"
 )
 
 var sessionStore *sessions.CookieStore
@@ -33,9 +33,13 @@ func LoadUserFromSession(conn *database.Conn, request *http.Request, user *model
 		return false, nil
 	}
 
-	if userID, ok := session.Values["userID"].(int); ok {
+	if userID, ok := session.Values["userID"].(int64); ok {
 		row := conn.QueryRow(
-			"select username from crypto_user where id = $1",
+			`select username
+			from crypto_user_login
+			where user_id = ?
+			order by updated_at desc
+			limit 1`,
 			userID,
 		)
 

--- a/migrations/001_initial_reverse.sql
+++ b/migrations/001_initial_reverse.sql
@@ -1,5 +1,4 @@
 DROP TABLE IF EXISTS crypto_alert;
-DROP TABLE IF EXISTS crypto_price;
+DROP TABLE IF EXISTS crypto_currency_prices;
 DROP TABLE IF EXISTS crypto_currency;
-DROP TABLE IF EXISTS crypto_session;
-DROP TABLE IF EXISTS crypto_user;
+DROP TABLE IF EXISTS crypto_user_login;

--- a/migrations/002_portfolio.sql
+++ b/migrations/002_portfolio.sql
@@ -1,21 +1,28 @@
-CREATE TABLE crypto_portfolio (
-    user_id integer NOT NULL,
-    currency_id integer NOT NULL,
-    cash numeric(40, 20) NOT NULL,
-    PRIMARY KEY (user_id),
-    FOREIGN KEY (user_id) REFERENCES crypto_user (id),
-    FOREIGN KEY (currency_id) REFERENCES crypto_currency (id),
-    CONSTRAINT positive_crypto_portfolio_cash CHECK (cash >= 0)
-);
+CREATE TABLE IF NOT EXISTS crypto_portfolio
+(
+    user_id Int64,
+    username LowCardinality(String),
+    currency_id Int64,
+    currency_ticker LowCardinality(String),
+    currency_name LowCardinality(String),
+    cash Float64,
+    updated_at DateTime64(9),
+    is_deleted UInt8
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_id, currency_id);
 
-CREATE TABLE crypto_asset (
-    user_id integer NOT NULL,
-    currency_id integer NOT NULL,
-    purchased numeric(40, 20) NOT NULL,
-    amount numeric(40, 20) NOT NULL,
-    PRIMARY KEY (user_id, currency_id),
-    FOREIGN KEY (user_id) REFERENCES crypto_user (id),
-    FOREIGN KEY (currency_id) REFERENCES crypto_currency (id),
-    CONSTRAINT positive_crypto_asset_purchase CHECK (purchased >= 0),
-    CONSTRAINT positive_crypto_asset_amount CHECK (amount >= 0)
-);
+CREATE TABLE IF NOT EXISTS crypto_asset
+(
+    user_id Int64,
+    username LowCardinality(String),
+    currency_id Int64,
+    currency_ticker LowCardinality(String),
+    currency_name LowCardinality(String),
+    purchased Float64,
+    amount Float64,
+    updated_at DateTime64(9),
+    is_deleted UInt8
+)
+ENGINE = ReplacingMergeTree(updated_at)
+ORDER BY (user_id, currency_id);

--- a/migrations/002_portfolio_reverse.sql
+++ b/migrations/002_portfolio_reverse.sql
@@ -1,2 +1,2 @@
-DROP TABLE IF EXISTS crypto_portfolio;
 DROP TABLE IF EXISTS crypto_asset;
+DROP TABLE IF EXISTS crypto_portfolio;

--- a/migrations/003_price_index.sql
+++ b/migrations/003_price_index.sql
@@ -1,1 +1,1 @@
-CREATE INDEX latest_crypto_price_idx ON crypto_price ("from", "to", "time" DESC);
+SELECT 1;

--- a/migrations/003_price_index_reverse.sql
+++ b/migrations/003_price_index_reverse.sql
@@ -1,1 +1,1 @@
-DROP INDEX IF EXISTS latest_crypto_price_idx;
+SELECT 1;

--- a/open-dbshell.sh
+++ b/open-dbshell.sh
@@ -3,4 +3,4 @@
 # shellcheck disable=SC2046
 export $(xargs < .env)
 
-PGPASSWORD="$DB_PASSWORD" psql -h "$DB_HOST" "$DB_NAME" "$DB_USERNAME"
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME"

--- a/scripts/load-clickhouse.sh
+++ b/scripts/load-clickhouse.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# shellcheck disable=SC2046
+export $(xargs < .env)
+
+EXPORT_DIR=${1:-export}
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_user_login (user_id, username, password_hash, created_at, updated_at, is_active) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_user_login.csv"
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_currency (id, ticker, name, updated_at) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_currency.csv"
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_currency_prices (time, from_currency_id, from_currency_ticker, from_currency_name, to_currency_id, to_currency_ticker, to_currency_name, value) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_currency_prices.csv"
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_alert (alert_id, user_id, username, from_currency_id, from_currency_ticker, from_currency_name, to_currency_id, to_currency_ticker, to_currency_name, value, above, alert_time, sent, updated_at, is_deleted) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_alert.csv"
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_portfolio (user_id, username, currency_id, currency_ticker, currency_name, cash, updated_at, is_deleted) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_portfolio.csv"
+
+clickhouse-client --host "$DB_HOST" --port "$DB_PORT" --user "$DB_USERNAME" --password "$DB_PASSWORD" --database "$DB_NAME" \
+  --query="INSERT INTO crypto_asset (user_id, username, currency_id, currency_ticker, currency_name, purchased, amount, updated_at, is_deleted) FORMAT CSVWithNames" \
+  < "${EXPORT_DIR}/crypto_asset.csv"

--- a/sql/condense-prices.sql
+++ b/sql/condense-prices.sql
@@ -1,27 +1,30 @@
-BEGIN;
+-- Remove non-aggregated rows before yesterday.
+ALTER TABLE crypto_currency_prices
+    DELETE WHERE time < now() - INTERVAL 1 DAY
+    AND time != toStartOfDay(time);
 
-CREATE TEMPORARY TABLE crypto_price_temp (
-    "from" integer NOT NULL,
-    "to" integer NOT NULL,
-    time timestamp without time zone NOT NULL,
-    value numeric(40, 20) NOT NULL
-);
-
--- Get the average price per day from before yesterday at midnight.
-INSERT INTO crypto_price_temp
-SELECT "from", "to", DATE_TRUNC('day', time) AS day, AVG(value)
-FROM crypto_price
-WHERE time < current_date - interval '1 day'
-GROUP BY "from", "to", day
-ORDER BY "from", "to", day;
-
--- Remove old records.
-DELETE FROM crypto_price WHERE time < current_date - interval '1 day';
-
--- Insert aggregated records.
-INSERT INTO crypto_price ("from", "to", time, value)
-SELECT "from", "to", time, value FROM crypto_price_temp;
-
-DROP TABLE crypto_price_temp;
-
-COMMIT;
+-- Insert aggregated daily averages for older data.
+INSERT INTO crypto_currency_prices
+    (time, from_currency_id, from_currency_ticker, from_currency_name,
+     to_currency_id, to_currency_ticker, to_currency_name, value, yearmonth)
+SELECT
+    toStartOfDay(time) AS time,
+    from_currency_id,
+    from_currency_ticker,
+    from_currency_name,
+    to_currency_id,
+    to_currency_ticker,
+    to_currency_name,
+    avg(value) AS value,
+    toUInt32((toYear(time) * 100) + toMonth(time)) AS yearmonth
+FROM crypto_currency_prices
+WHERE time < now() - INTERVAL 1 DAY
+    AND time != toStartOfDay(time)
+GROUP BY
+    from_currency_id,
+    from_currency_ticker,
+    from_currency_name,
+    to_currency_id,
+    to_currency_ticker,
+    to_currency_name,
+    toStartOfDay(time);


### PR DESCRIPTION
### Motivation

- Replace the Postgres storage layer with ClickHouse for denormalized, high-volume time series storage for crypto prices and audit-friendly append-only records for users, portfolios and alerts. 
- Use a single `crypto_currency_prices` table as the canonical price store and adopt ClickHouse-friendly schemas for `crypto_user_login`, `crypto_asset`, `crypto_portfolio`, and `crypto_alert` to simplify reads and aggregation. 
- Keep historical changes (updates/deletes) as append-only rows using `ReplacingMergeTree` semantics so the application can query the latest state via ordering. 
- Provide a migration path from an existing Postgres instance by exporting CSVs and loading them into ClickHouse.

### Description

- Replaced the Postgres DB wrapper with a ClickHouse client in `internal/database/database.go` and added helper functions `HashID` and `RandomID` for deterministic/random IDs. 
- Converted table migrations to ClickHouse DDLs and added the `crypto_currency_prices` table definition matching the provided schema, plus ClickHouse versions of `crypto_user_login`, `crypto_asset`, `crypto_portfolio`, and `crypto_alert` in `migrations/*`. 
- Updated ingestion, alerting, portfolio, and auth flows to use denormalized ClickHouse queries, `PrepareBatch` inserts, `?` placeholders, and conversion helpers (e.g. `decimalToFloat`, `boolToUint`) across `cmd/ingest`, `cmd/notify`, `internal/route/*`, and `cmd/adduser`. 
- Added a new tool to export current Postgres data to CSV with `cmd/export-postgres/main.go` and a Bash loader script `scripts/load-clickhouse.sh` which uses `clickhouse-client` to import CSVs into ClickHouse, and updated `open-dbshell.sh`/`condense-prices.sh` to use ClickHouse client/SQL.

### Testing

- Ran `gofmt -w` across modified files to ensure formatting, which completed successfully. 
- Ran `go mod tidy` to fetch and update modules, which failed due to network/proxy restrictions when downloading ClickHouse-related modules. 
- Retried with `GOPROXY=direct go mod tidy` which also failed because of outbound access restrictions to GitHub. 
- No other automated test suite was run in the environment; runtime verification will require network access to fetch Go modules and a running ClickHouse instance to apply migrations and import CSVs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69602d9647d4832abc39c0dd8058e1e6)